### PR TITLE
Feature Request: Include warnings and errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,14 +7,12 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.0)
-    codecov (0.1.14)
-      json
-      simplecov
-      url
+    codecov (0.6.0)
+      simplecov (>= 0.15, < 0.22)
     coderay (1.1.2)
     diff-lcs (1.3)
     docile (1.3.1)
-    ffi (1.10.0)
+    ffi (1.15.5)
     formatador (0.2.5)
     guard (2.15.0)
       formatador (>= 0.2.4)
@@ -88,13 +86,12 @@ GEM
     simplecov-html (0.10.2)
     thor (0.20.3)
     unicode-display_width (1.5.0)
-    url (0.3.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  codecov (~> 0.1)
+  codecov (~> 0.6)
   flutter_analyze_parser!
   guard-rspec (~> 4.7)
   rake (~> 10.0)

--- a/flutter_analyze_parser.gemspec
+++ b/flutter_analyze_parser.gemspec
@@ -15,5 +15,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop", "~> 0.6"
   spec.add_development_dependency "rubocop-performance", "~> 1.0"
   spec.add_development_dependency "simplecov", "~> 0.16"
-  spec.add_development_dependency "codecov", "~> 0.1"
+  spec.add_development_dependency "codecov", "~> 0.6"
 end

--- a/lib/flutter_analyze_parser.rb
+++ b/lib/flutter_analyze_parser.rb
@@ -1,4 +1,4 @@
-FlutterViolation = Struct.new(:rule, :description, :file, :line)
+FlutterViolation = Struct.new(:severity, :rule, :description, :file, :line)
 
 class FlutterAnalyzeParser
   class << self
@@ -8,7 +8,7 @@ class FlutterAnalyzeParser
       return [] if filtered_input.detect { |element| element.include? "No issues found!" }
 
       filtered_input
-        .select { |line| line.start_with? "info" }
+        .select { |line| line.start_with? "info", "warning", "error" }
         .map(&method(:parse_line))
     end
 
@@ -21,10 +21,10 @@ class FlutterAnalyzeParser
     end
 
     def parse_line(line)
-      _, description, file_with_line_number, rule = line.split(" • ")
+      severity, description, file_with_line_number, rule = line.split(" • ")
       file, line = file_with_line_number.split(":")
 
-      FlutterViolation.new(rule, description, file, line.to_i)
+      FlutterViolation.new(severity, rule, description, file, line.to_i)
     end
   end
 end

--- a/spec/fixtures/test_input_with_violations.txt
+++ b/spec/fixtures/test_input_with_violations.txt
@@ -7,6 +7,8 @@ Analyzing my_flutter_project...
    info • Prefer const with constant constructors • lib/main.dart:13:13 • prefer_const_constructors
    info • Name types using UpperCamelCase • lib/main.dart:19:7 • camel_case_types
 
+warning • 'demo' isn't a recognized error code • analysis_options.yaml:5:5 • unrecognized_error_code
+  error • The argument type 'Null' can't be assigned to the parameter type 'String' • lib/main.dart:14:14 • argument_type_not_assignable
 
    info • Name types using UpperCamelCase • lib/main.dart:27:7 • camel_case_types
    info • Prefer const with constant constructors • lib/pages/home_page.dart:49:10 • prefer_const_constructors

--- a/spec/flutter_analyze_parser_spec.rb
+++ b/spec/flutter_analyze_parser_spec.rb
@@ -29,13 +29,14 @@ RSpec.describe FlutterAnalyzeParser do
         expect(violations).not_to be_empty
       end
 
-      it "should have 5 items" do
-        expect(violations.length).to eq(5)
+      it "should have 7 items" do
+        expect(violations.length).to eq(7)
       end
 
       describe "1st item" do
         it "should have correct fields" do
           expected = FlutterViolation.new(
+            "info",
             "camel_case_types",
             "Name types using UpperCamelCase",
             "lib/main.dart",
@@ -46,9 +47,38 @@ RSpec.describe FlutterAnalyzeParser do
         end
       end
 
+      describe "4st item" do
+        it "should have correct fields" do
+          expected = FlutterViolation.new(
+            "warning",
+            "unrecognized_error_code",
+            "'demo' isn't a recognized error code",
+            "analysis_options.yaml",
+            5
+          )
+
+          expect(violations.fetch(3)).to eq(expected)
+        end
+      end
+
+      describe "5st item" do
+        it "should have correct fields" do
+          expected = FlutterViolation.new(
+            "error",
+            "argument_type_not_assignable",
+            "The argument type 'Null' can't be assigned to the parameter type 'String'",
+            "lib/main.dart",
+            14
+          )
+
+          expect(violations.fetch(4)).to eq(expected)
+        end
+      end
+
       describe "last item" do
         it "should have correct fields" do
           expected = FlutterViolation.new(
+            "info",
             "prefer_const_constructors",
             "Prefer const with constant constructors",
             "lib/pages/home_page.dart",


### PR DESCRIPTION
@mateuszszklarek 
Thanks for the great plugin!

**I'll open after #3 merged.**


---

## Overview

The results of a `flutter analyze` run may also include `warning` and `error`.

demo 
https://github.com/blendthink/danger-flutter-lint-demo/pull/1

I would like to extract the `warning` and `error` and comment on the Pull Request.