### PR TITLE
Support `warning` lines from Flutter analyzer

### DIFF
--- a/flutter_analyze_parser.gemspec
+++ b/flutter_analyze_parser.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "flutter_analyze_parser"
-  spec.version       = "0.1.2"
+  spec.version       = "0.1.3"
   spec.authors       = ["Mateusz Szklarek"]
   spec.email         = ["mateusz.szklarek@gmail.com"]
   spec.summary       = "Parser for flutter analyze output"

--- a/lib/flutter_analyze_parser.rb
+++ b/lib/flutter_analyze_parser.rb
@@ -8,7 +8,7 @@ class FlutterAnalyzeParser
       return [] if filtered_input.detect { |element| element.include? "No issues found!" }
 
       filtered_input
-        .select { |line| line.start_with? "info" }
+        .select { |line| line.start_with?("info", "warning") }
         .map(&method(:parse_line))
     end
 

--- a/spec/fixtures/test_input_with_violations.txt
+++ b/spec/fixtures/test_input_with_violations.txt
@@ -7,6 +7,9 @@ Analyzing my_flutter_project...
    info • Prefer const with constant constructors • lib/main.dart:13:13 • prefer_const_constructors
    info • Name types using UpperCamelCase • lib/main.dart:19:7 • camel_case_types
 
+   warning • The '!' will have no effect because the receiver can't be null • lib/main.dart:30:7 • unnecessary_non_null_assertion
 
    info • Name types using UpperCamelCase • lib/main.dart:27:7 • camel_case_types
    info • Prefer const with constant constructors • lib/pages/home_page.dart:49:10 • prefer_const_constructors
+
+   

--- a/spec/flutter_analyze_parser_spec.rb
+++ b/spec/flutter_analyze_parser_spec.rb
@@ -45,6 +45,19 @@ RSpec.describe FlutterAnalyzeParser do
           expect(violations.first).to eq(expected)
         end
       end
+      
+      describe "4th item" do
+        it "should have correct fields" do
+          expected = FlutterViolation.new(
+            "unnecessary_non_null_assertion",
+            "Avoid using unnecessary non-null assertions",
+            "lib/main.dart",
+            30
+          )
+
+          expect(violations[3]).to eq(expected)
+        end
+      end
 
       describe "last item" do
         it "should have correct fields" do


### PR DESCRIPTION
## Summary

Support `warning` lines from the Flutter analyzer in addition to `info` so the parser reports those issues to users.

Flutter analyzer emits some issues as `warning` instead of `info`. Without this change, those warnings are silently ignored and developers miss actionable feedback.

## Flutter warning example

```dart
String value = '';
// This is a warning:
// "The '!' will have no effect because the receiver can't be null.
// (unnecessary_non_null_assertion)"
value!.toString();
```
## Future improvements

Although this is the most straightforward solution, it could be improved by using some `level` (e.g. `info`, `warning`, `error`) variable to control which messages should be parsed as well, given DevOps more options for configurations.

